### PR TITLE
Implement SQLite-first simple mode lookup pipeline

### DIFF
--- a/src/context-bundle.ts
+++ b/src/context-bundle.ts
@@ -1,12 +1,10 @@
 import Database from 'better-sqlite3';
-import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
 import { DEFAULT_DB_FILENAME } from './constants.js';
 
 export interface ContextBundleSymbolSelector {
   name: string;
-  kind?: string;
 }
 
 export interface ContextBundleOptions {
@@ -14,326 +12,213 @@ export interface ContextBundleOptions {
   databaseName?: string;
   file: string;
   symbol?: ContextBundleSymbolSelector;
-  maxSnippets?: number;
-  maxNeighbors?: number;
+  budgetTokens?: number;
 }
 
-export interface BundleFileMetadata {
-  path: string;
-  size: number;
-  modified: number;
-  hash: string;
-  lastIndexedAt: number;
+export interface BundleSymbol {
+  name: string;
+  startLine: number;
+  endLine: number;
+  hits: number;
 }
 
 export interface BundleSnippet {
-  source: 'chunk' | 'content';
-  chunkIndex: number | null;
-  content: string;
-  byteStart: number | null;
-  byteEnd: number | null;
-  lineStart: number | null;
-  lineEnd: number | null;
-}
-
-export interface BundleDefinition {
-  id: string;
-  name: string;
-  kind: string;
-  signature: string | null;
-  rangeStart: number | null;
-  rangeEnd: number | null;
-  metadata: Record<string, unknown> | null;
-}
-
-export interface BundleEdgeNeighbor {
-  id: string;
-  type: string;
-  direction: 'incoming' | 'outgoing';
-  metadata: Record<string, unknown> | null;
-  fromNodeId: string;
-  toNodeId: string;
-  neighbor: {
-    id: string;
-    path: string | null;
-    kind: string;
-    name: string;
-    signature: string | null;
-    metadata: Record<string, unknown> | null;
-  };
-}
-
-export interface BundleIngestionSummary {
-  id: string;
-  finishedAt: number;
-  durationMs: number;
-  fileCount: number;
+  snippetId: number;
+  text: string;
+  startLine: number;
+  endLine: number;
 }
 
 export interface ContextBundleResult {
   databasePath: string;
-  file: BundleFileMetadata;
-  definitions: BundleDefinition[];
-  focusDefinition: BundleDefinition | null;
-  related: BundleEdgeNeighbor[];
+  file: string;
+  tokenBudget: number;
+  estimatedTokens: number;
+  focusSymbol: BundleSymbol | null;
+  definitions: BundleSymbol[];
   snippets: BundleSnippet[];
-  latestIngestion: BundleIngestionSummary | null;
+  citations: Record<string, Array<[number, number]>>;
   warnings: string[];
 }
 
-interface FileRow {
-  path: string;
-  size: number;
-  modified: number;
-  hash: string;
-  lastIndexedAt: number;
-  content: string | null;
-}
-
-interface ChunkRow {
-  chunkIndex: number;
-  content: string;
-  byteStart: number | null;
-  byteEnd: number | null;
-  lineStart: number | null;
-  lineEnd: number | null;
-}
-
-interface NodeRow {
-  id: string;
+interface SymbolRow {
   name: string;
-  kind: string;
-  signature: string | null;
-  rangeStart: number | null;
-  rangeEnd: number | null;
-  metadata: string | null;
+  startLine: number;
+  endLine: number;
+  hits: number;
 }
 
-interface EdgeRow {
-  id: string;
-  type: string;
-  metadata: string | null;
-  sourceId: string;
-  targetId: string;
-  neighborId: string;
-  neighborPath: string | null;
-  neighborKind: string;
-  neighborName: string;
-  neighborSignature: string | null;
-  neighborMetadata: string | null;
+interface SnippetRow {
+  id: number;
+  text: string;
+  startLine: number;
+  endLine: number;
+  hits: number;
 }
 
-function parseMetadata(payload: string | null): Record<string, unknown> | null {
-  if (!payload) {
-    return null;
+const DEFAULT_TOKEN_BUDGET = 3000;
+const MIN_TOKEN_BUDGET = 500;
+const METADATA_TOKEN_RESERVE = 200;
+
+function normalizeBudget(explicit?: number): number {
+  if (explicit !== undefined && Number.isFinite(explicit)) {
+    return Math.max(MIN_TOKEN_BUDGET, Math.floor(explicit));
   }
-
-  try {
-    return JSON.parse(payload) as Record<string, unknown>;
-  } catch (error) {
-    return {
-      parseError: error instanceof Error ? error.message : String(error)
-    };
+  const envValue = Number(process.env.INDEX_MCP_BUDGET_TOKENS);
+  if (Number.isFinite(envValue) && envValue > 0) {
+    return Math.max(MIN_TOKEN_BUDGET, Math.floor(envValue));
   }
+  return DEFAULT_TOKEN_BUDGET;
 }
 
-function clamp(value: number, min: number, max: number): number {
-  return Math.max(min, Math.min(max, value));
+function estimateTokens(text: string): number {
+  if (!text) {
+    return 0;
+  }
+  return Math.ceil(text.length / 4);
+}
+
+function toBundleSymbol(row: SymbolRow): BundleSymbol {
+  return {
+    name: row.name,
+    startLine: row.startLine,
+    endLine: row.endLine,
+    hits: row.hits
+  };
+}
+
+function buildCitations(file: string, snippets: BundleSnippet[]): Record<string, Array<[number, number]>> {
+  const map: Record<string, Array<[number, number]>> = {};
+  if (!snippets.length) {
+    return map;
+  }
+  map[file] = snippets.map((snippet) => [snippet.startLine, snippet.endLine]);
+  return map;
+}
+
+function sortDefinitions(definitions: BundleSymbol[]): BundleSymbol[] {
+  return [...definitions].sort((a, b) => {
+    if (b.hits !== a.hits) {
+      return b.hits - a.hits;
+    }
+    return a.startLine - b.startLine;
+  });
 }
 
 export async function getContextBundle(options: ContextBundleOptions): Promise<ContextBundleResult> {
   const absoluteRoot = path.resolve(options.root);
-  const stats = await fs.stat(absoluteRoot);
-  if (!stats.isDirectory()) {
-    throw new Error(`Context bundle root must be a directory: ${absoluteRoot}`);
-  }
-
   const databasePath = path.join(absoluteRoot, options.databaseName ?? DEFAULT_DB_FILENAME);
-  const db = new Database(databasePath, { readonly: true, fileMustExist: true });
+  const tokenBudget = normalizeBudget(options.budgetTokens);
 
+  const db = new Database(databasePath, { fileMustExist: true });
   try {
-    const fileRow = db
+    const symbolRows = db
       .prepare(
-        `SELECT path, size, modified, hash, last_indexed_at as lastIndexedAt, content
-         FROM files
-         WHERE path = ?`
+        `SELECT name, start_line as startLine, end_line as endLine, hits
+         FROM symbols
+         WHERE file = ?`
       )
-      .get(options.file) as FileRow | undefined;
+      .all(options.file) as SymbolRow[];
 
-    if (!fileRow) {
-      throw new Error(`No file metadata found for '${options.file}'. Ensure the path is relative to the workspace root.`);
+    if (!symbolRows.length) {
+      throw new Error(`No symbols indexed for '${options.file}'. Run ingest_codebase first.`);
     }
 
-    const snippetLimit = clamp(options.maxSnippets ?? 3, 0, 10);
-    const neighborLimit = clamp(options.maxNeighbors ?? 12, 0, 50);
+    const definitions = sortDefinitions(symbolRows).slice(0, 24).map(toBundleSymbol);
 
-    const chunkRows = snippetLimit
-      ? (db
-          .prepare(
-            `SELECT chunk_index as chunkIndex, content, byte_start as byteStart, byte_end as byteEnd, line_start as lineStart, line_end as lineEnd
-             FROM file_chunks
-             WHERE path = ?
-             ORDER BY chunk_index ASC
-             LIMIT ?`
-          )
-          .all(options.file, snippetLimit) as ChunkRow[])
-      : [];
+    const focusName = options.symbol?.name?.toLowerCase();
+    const focusSymbol = focusName
+      ? definitions.find((definition) => definition.name.toLowerCase() === focusName) ?? null
+      : definitions[0] ?? null;
 
-    const nodeRows = db
+    const snippetRows = db
       .prepare(
-        `SELECT id, name, kind, signature, range_start as rangeStart, range_end as rangeEnd, metadata
-         FROM code_graph_nodes
-         WHERE path = ?
-         ORDER BY COALESCE(range_start, 9223372036854775807), name`
+        `SELECT id, text, start_line as startLine, end_line as endLine, hits
+         FROM snippets
+         WHERE file = ?
+         ORDER BY hits DESC, start_line ASC`
       )
-      .all(options.file) as NodeRow[];
+      .all(options.file) as SnippetRow[];
 
-    const definitions: BundleDefinition[] = nodeRows.map((row) => ({
-      id: row.id,
-      name: row.name,
-      kind: row.kind,
-      signature: row.signature,
-      rangeStart: row.rangeStart,
-      rangeEnd: row.rangeEnd,
-      metadata: parseMetadata(row.metadata)
-    }));
-
-    let focusDefinition: BundleDefinition | null = null;
-    if (options.symbol) {
-      const { name, kind } = options.symbol;
-      focusDefinition =
-        definitions.find((def) => def.name === name && (!kind || def.kind === kind)) ??
-        definitions.find((def) => def.name === name) ??
-        null;
+    if (!snippetRows.length) {
+      throw new Error(`No snippets indexed for '${options.file}'.`);
     }
 
-    const focusNodeIds = new Set<string>();
-    if (focusDefinition) {
-      focusNodeIds.add(focusDefinition.id);
-    } else {
-      for (const definition of definitions) {
-        focusNodeIds.add(definition.id);
+    const selectedSnippets: BundleSnippet[] = [];
+    let usedTokens = METADATA_TOKEN_RESERVE;
+    const warnings: string[] = [];
+
+    const seenSnippetIds = new Set<number>();
+
+    const addSnippet = (row: SnippetRow) => {
+      if (seenSnippetIds.has(row.id)) {
+        return;
+      }
+      const snippetTokens = estimateTokens(row.text);
+      if (usedTokens + snippetTokens > tokenBudget) {
+        warnings.push(`Token budget reached before including snippet covering lines ${row.startLine}-${row.endLine}.`);
+        return;
+      }
+      usedTokens += snippetTokens;
+      selectedSnippets.push({
+        snippetId: row.id,
+        text: row.text,
+        startLine: row.startLine,
+        endLine: row.endLine
+      });
+      seenSnippetIds.add(row.id);
+    };
+
+    if (focusSymbol) {
+      const coveringSnippet = snippetRows.find(
+        (row) => row.startLine <= focusSymbol.startLine && row.endLine >= focusSymbol.startLine
+      );
+      if (coveringSnippet) {
+        addSnippet(coveringSnippet);
       }
     }
 
-    let related: BundleEdgeNeighbor[] = [];
-    if (neighborLimit > 0 && focusNodeIds.size > 0) {
-      const placeholders = Array.from(focusNodeIds).map(() => '?').join(', ');
-      const params = Array.from(focusNodeIds);
-
-      const outgoingRows = db
-        .prepare(
-          `SELECT e.id, e.type, e.metadata, e.source_id as sourceId, e.target_id as targetId,
-                  n.id as neighborId, n.path as neighborPath, n.kind as neighborKind, n.name as neighborName,
-                  n.signature as neighborSignature, n.metadata as neighborMetadata
-           FROM code_graph_edges e
-           JOIN code_graph_nodes n ON n.id = e.target_id
-           WHERE e.source_id IN (${placeholders})
-           LIMIT ?`
-        )
-        .all(...params, neighborLimit) as EdgeRow[];
-
-      const incomingRows = db
-        .prepare(
-          `SELECT e.id, e.type, e.metadata, e.source_id as sourceId, e.target_id as targetId,
-                  n.id as neighborId, n.path as neighborPath, n.kind as neighborKind, n.name as neighborName,
-                  n.signature as neighborSignature, n.metadata as neighborMetadata
-           FROM code_graph_edges e
-           JOIN code_graph_nodes n ON n.id = e.source_id
-           WHERE e.target_id IN (${placeholders})
-           LIMIT ?`
-        )
-        .all(...params, neighborLimit) as EdgeRow[];
-
-      const mapEdges = (rows: EdgeRow[], direction: 'incoming' | 'outgoing'): BundleEdgeNeighbor[] =>
-        rows.map((row) => ({
-          id: row.id,
-          type: row.type,
-          direction,
-          metadata: parseMetadata(row.metadata),
-          fromNodeId: row.sourceId,
-          toNodeId: row.targetId,
-          neighbor: {
-            id: row.neighborId,
-            path: row.neighborPath,
-            kind: row.neighborKind,
-            name: row.neighborName,
-            signature: row.neighborSignature,
-            metadata: parseMetadata(row.neighborMetadata)
-          }
-        }));
-
-      related = [...mapEdges(outgoingRows, 'outgoing'), ...mapEdges(incomingRows, 'incoming')];
+    for (const row of snippetRows) {
+      if (usedTokens >= tokenBudget) {
+        break;
+      }
+      addSnippet(row);
     }
 
-    const snippets: BundleSnippet[] = chunkRows.map((row) => ({
-      source: 'chunk',
-      chunkIndex: row.chunkIndex,
-      content: row.content,
-      byteStart: row.byteStart,
-      byteEnd: row.byteEnd,
-      lineStart: row.lineStart,
-      lineEnd: row.lineEnd
-    }));
-
-    if (!snippets.length && fileRow.content && snippetLimit > 0) {
-      const lines = fileRow.content.split(/\r?\n/);
-      const slice = lines.slice(0, Math.max(1, snippetLimit * 5));
-      const content = slice.join('\n');
-      const byteEnd = Buffer.byteLength(content, 'utf8');
-      snippets.push({
-        source: 'content',
-        chunkIndex: null,
-        content,
-        byteStart: 0,
-        byteEnd,
-        lineStart: 1,
-        lineEnd: slice.length
-      });
+    if (!selectedSnippets.length) {
+      addSnippet(snippetRows[0]);
     }
 
-    const latestIngestionRow = db
-      .prepare(
-        `SELECT id, finished_at as finishedAt, started_at as startedAt, file_count as fileCount
-         FROM ingestions
-         ORDER BY finished_at DESC
-         LIMIT 1`
-      )
-      .get() as { id: string; finishedAt: number; startedAt: number; fileCount: number } | undefined;
+    selectedSnippets.sort((a, b) => a.startLine - b.startLine);
 
-    const latestIngestion: BundleIngestionSummary | null = latestIngestionRow
-      ? {
-          id: latestIngestionRow.id,
-          finishedAt: latestIngestionRow.finishedAt,
-          durationMs: latestIngestionRow.finishedAt - latestIngestionRow.startedAt,
-          fileCount: latestIngestionRow.fileCount
-        }
-      : null;
-
-    const file: BundleFileMetadata = {
-      path: fileRow.path,
-      size: fileRow.size,
-      modified: fileRow.modified,
-      hash: fileRow.hash,
-      lastIndexedAt: fileRow.lastIndexedAt
-    };
-
-    const warnings: string[] = [];
-    if (!snippets.length) {
-      warnings.push('No content snippets were available for the requested file.');
+    const updateSnippetStmt = db.prepare('UPDATE snippets SET hits = hits + 1 WHERE id = ?');
+    for (const snippet of selectedSnippets) {
+      updateSnippetStmt.run(snippet.snippetId);
     }
-    if (!definitions.length) {
-      warnings.push('No graph metadata recorded for the requested file.');
+
+    const updateSymbolStmt = db.prepare(
+      'UPDATE symbols SET hits = hits + 1 WHERE name = ? AND file = ? AND start_line = ?'
+    );
+    const updatedSymbols = new Set<string>();
+    for (const symbol of definitions) {
+      if (updatedSymbols.has(symbol.name)) {
+        continue;
+      }
+      updateSymbolStmt.run(symbol.name, options.file, symbol.startLine);
+      updatedSymbols.add(symbol.name);
     }
+
+    const estimatedTokens = usedTokens;
 
     return {
       databasePath,
-      file,
+      file: options.file,
+      tokenBudget,
+      estimatedTokens,
+      focusSymbol,
       definitions,
-      focusDefinition,
-      related,
-      snippets,
-      latestIngestion,
+      snippets: selectedSnippets,
+      citations: buildCitations(options.file, selectedSnippets),
       warnings
     };
   } finally {

--- a/src/input-normalizer.ts
+++ b/src/input-normalizer.ts
@@ -160,8 +160,7 @@ export function normalizeSearchArgs(raw: unknown): UnknownRecord {
     root: ['path', 'project_path', 'workspace_root', 'working_directory'],
     query: ['text', 'search', 'search_query'],
     databaseName: ['database', 'database_path', 'db'],
-    limit: ['max_results', 'top_k'],
-    model: ['embedding_model']
+    limit: ['max_results', 'top_k']
   });
 
   normalizeRootField(record);
@@ -186,10 +185,8 @@ export function normalizeLookupArgs(raw: unknown): UnknownRecord {
     node: ['graph_node', 'graph_target', 'target', 'entity'],
     databaseName: ['database', 'database_path', 'db'],
     limit: ['max_results', 'top_k', 'max_neighbors'],
-    maxSnippets: ['snippet_limit', 'max_chunks'],
-    maxNeighbors: ['neighbor_limit', 'edge_limit'],
     direction: ['edge_direction'],
-    model: ['embedding_model']
+    budgetTokens: ['token_budget']
   });
 
   normalizeRootField(record);
@@ -197,6 +194,8 @@ export function normalizeLookupArgs(raw: unknown): UnknownRecord {
   if (typeof record.mode === 'string') {
     record.mode = record.mode.trim().toLowerCase();
   }
+
+  coerceNumber(record, 'budgetTokens');
 
   if (typeof record.query === 'string') {
     const queryText = record.query.trim();
@@ -251,9 +250,6 @@ export function normalizeLookupArgs(raw: unknown): UnknownRecord {
   }
 
   coerceNumber(record, 'limit');
-  coerceNumber(record, 'maxSnippets');
-  coerceNumber(record, 'maxNeighbors');
-
   if (typeof record.direction === 'string') {
     record.direction = record.direction.trim().toLowerCase();
   }
@@ -404,13 +400,11 @@ export function normalizeContextBundleArgs(raw: unknown): UnknownRecord {
     databaseName: ['database', 'database_path', 'db'],
     file: ['file_path', 'relative_path', 'target_path'],
     symbol: ['symbol_selector', 'target_symbol'],
-    maxSnippets: ['snippet_limit', 'max_chunks'],
-    maxNeighbors: ['neighbor_limit', 'edge_limit', 'max_edges']
+    budgetTokens: ['token_budget']
   });
 
   normalizeRootField(record);
-  coerceNumber(record, 'maxSnippets');
-  coerceNumber(record, 'maxNeighbors');
+  coerceNumber(record, 'budgetTokens');
 
   const symbolValue = record.symbol;
   if (typeof symbolValue === 'string') {

--- a/src/lookup.ts
+++ b/src/lookup.ts
@@ -1,0 +1,168 @@
+import Database from 'better-sqlite3';
+import path from 'node:path';
+
+import { getContextBundle, type ContextBundleResult } from './context-bundle.js';
+import { semanticSearch, type SemanticSearchResult } from './search.js';
+import { DEFAULT_DB_FILENAME } from './constants.js';
+
+interface SymbolRow {
+  name: string;
+  file: string;
+  startLine: number;
+  endLine: number;
+  hits: number;
+}
+
+export interface AutoLookupOptions {
+  root: string;
+  databaseName?: string;
+  query?: string;
+  file?: string;
+  symbolName?: string;
+  budgetTokens?: number;
+  limit?: number;
+}
+
+export interface AutoLookupResult {
+  databasePath: string;
+  mode: 'symbol' | 'file' | 'search' | 'none';
+  summary: string;
+  bundle?: ContextBundleResult;
+  search?: SemanticSearchResult;
+  confidence: number;
+}
+
+const LOW_CONFIDENCE_THRESHOLD = 0.35;
+
+function resolveDatabasePath(root: string, databaseName?: string): string {
+  const absoluteRoot = path.resolve(root);
+  return path.join(absoluteRoot, databaseName ?? DEFAULT_DB_FILENAME);
+}
+
+function findSymbolMatch(db: Database.Database, symbolName: string, file?: string): SymbolRow | null {
+  const trimmed = symbolName.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const matcher = db.prepare(
+    `SELECT name, file, start_line as startLine, end_line as endLine, hits
+       FROM symbols
+      WHERE LOWER(name) = LOWER(?)${file ? ' AND file = ?' : ''}
+      ORDER BY hits DESC, start_line ASC
+      LIMIT 1`
+  );
+  const row = file ? (matcher.get(trimmed, file) as SymbolRow | undefined) : (matcher.get(trimmed) as SymbolRow | undefined);
+  return row ?? null;
+}
+
+export async function autoLookup(options: AutoLookupOptions): Promise<AutoLookupResult> {
+  const databasePath = resolveDatabasePath(options.root, options.databaseName);
+  const db = new Database(databasePath, { readonly: true, fileMustExist: true });
+  let symbolMatch: SymbolRow | null = null;
+  try {
+    if (options.symbolName) {
+      symbolMatch = findSymbolMatch(db, options.symbolName, options.file);
+      if (!symbolMatch && options.file) {
+        // Attempt partial match when file hint provided.
+        symbolMatch = db
+          .prepare(
+            `SELECT name, file, start_line as startLine, end_line as endLine, hits
+               FROM symbols
+              WHERE file = ? AND LOWER(name) LIKE LOWER(?)
+              ORDER BY hits DESC, start_line ASC
+              LIMIT 1`
+          )
+          .get(options.file, `${options.symbolName.trim().toLowerCase()}%`) as SymbolRow | undefined ?? null;
+      }
+    }
+  } finally {
+    db.close();
+  }
+
+  if (symbolMatch) {
+    const bundle = await getContextBundle({
+      root: options.root,
+      databaseName: options.databaseName,
+      file: symbolMatch.file,
+      symbol: { name: symbolMatch.name },
+      budgetTokens: options.budgetTokens
+    });
+    const summary = `Focused context for symbol '${symbolMatch.name}' in ${symbolMatch.file} (${bundle.estimatedTokens}/${bundle.tokenBudget} tokens).`;
+    return {
+      databasePath,
+      mode: 'symbol',
+      summary,
+      bundle,
+      confidence: 1
+    };
+  }
+
+  if (options.file) {
+    const bundle = await getContextBundle({
+      root: options.root,
+      databaseName: options.databaseName,
+      file: options.file,
+      symbol: options.symbolName ? { name: options.symbolName } : undefined,
+      budgetTokens: options.budgetTokens
+    });
+    const summary = `Context bundle for ${options.file} (${bundle.estimatedTokens}/${bundle.tokenBudget} tokens).`;
+    return {
+      databasePath,
+      mode: 'file',
+      summary,
+      bundle,
+      confidence: 0.75
+    };
+  }
+
+  if (options.query) {
+    const search = await semanticSearch({
+      root: options.root,
+      query: options.query,
+      databaseName: options.databaseName,
+      limit: options.limit
+    });
+
+    const topMatch = search.results[0] ?? null;
+    const confidence = topMatch?.confidence ?? 0;
+
+    if (!topMatch) {
+      const summary = 'Search completed but no matching snippets were found.';
+      return {
+        databasePath,
+        mode: 'search',
+        summary,
+        search,
+        confidence
+      };
+    }
+
+    const bundle = await getContextBundle({
+      root: options.root,
+      databaseName: options.databaseName,
+      file: topMatch.file,
+      budgetTokens: options.budgetTokens
+    });
+
+    const tokenDescriptor = `${bundle.estimatedTokens}/${bundle.tokenBudget} tokens`;
+    const summary = confidence < LOW_CONFIDENCE_THRESHOLD
+      ? `Low-confidence search match in ${topMatch.file}; review recommended. (${tokenDescriptor})`
+      : `Search matched ${topMatch.file} with confidence ${(confidence * 100).toFixed(1)}% (${tokenDescriptor}).`;
+
+    return {
+      databasePath,
+      mode: 'search',
+      summary,
+      bundle,
+      search,
+      confidence
+    };
+  }
+
+  return {
+    databasePath,
+    mode: 'none',
+    summary: 'No lookup target provided.',
+    confidence: 0
+  };
+}

--- a/src/search.ts
+++ b/src/search.ts
@@ -1,21 +1,15 @@
 import Database from 'better-sqlite3';
-import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
-import { bufferToFloat32Array, embedTexts } from './embedding.js';
 import { DEFAULT_DB_FILENAME } from './constants.js';
 
-interface ChunkRow {
-  id: string;
-  path: string;
-  chunkIndex: number;
-  content: string;
-  embedding: Buffer;
-  embeddingModel: string;
-  byteStart: number | null;
-  byteEnd: number | null;
-  lineStart: number | null;
-  lineEnd: number | null;
+interface SnippetRow {
+  id: number;
+  file: string;
+  text: string;
+  startLine: number;
+  endLine: number;
+  score: number;
 }
 
 export interface SemanticSearchOptions {
@@ -23,91 +17,68 @@ export interface SemanticSearchOptions {
   query: string;
   databaseName?: string;
   limit?: number;
-  model?: string;
 }
 
 export interface SemanticSearchMatch {
-  path: string;
-  chunkIndex: number;
+  file: string;
+  snippetId: number;
   score: number;
-  content: string;
-  embeddingModel: string;
-  byteStart: number | null;
-  byteEnd: number | null;
-  lineStart: number | null;
-  lineEnd: number | null;
-  contextBefore: string | null;
-  contextAfter: string | null;
+  confidence: number;
+  text: string;
+  startLine: number;
+  endLine: number;
 }
 
 export interface SemanticSearchResult {
   databasePath: string;
-  embeddingModel: string | null;
-  totalChunks: number;
-  evaluatedChunks: number;
+  totalSnippets: number;
+  evaluatedSnippets: number;
   results: SemanticSearchMatch[];
+  query: string;
 }
 
 const DEFAULT_RESULT_LIMIT = 8;
 const MAX_RESULT_LIMIT = 50;
-const CONTEXT_LINE_PADDING = 2;
-
-interface FileCacheEntry {
-  content: string | null;
-  lines: string[] | null;
-  trimmed: string | null;
-  trimmedLines: string[] | null;
-}
-
-function dotProduct(a: Float32Array, b: Float32Array): number {
-  if (a.length !== b.length) {
-    throw new Error('Mismatched embedding dimensions encountered during search');
-  }
-
-  let sum = 0;
-  for (let i = 0; i < a.length; i += 1) {
-    sum += a[i] * b[i];
-  }
-  return sum;
-}
-
-function insertIntoTopMatches(
-  sortedMatches: SemanticSearchMatch[],
-  candidate: SemanticSearchMatch,
-  limit: number
-): void {
-  if (limit <= 0) {
-    return;
-  }
-
-  const insertionIndex = sortedMatches.findIndex((match) => match.score > candidate.score);
-  if (insertionIndex === -1) {
-    sortedMatches.push(candidate);
-  } else {
-    sortedMatches.splice(insertionIndex, 0, candidate);
-  }
-
-  if (sortedMatches.length > limit) {
-    sortedMatches.shift();
-  }
-}
 
 function normalizeResultLimit(limit: number | undefined): number {
   if (limit === undefined || Number.isNaN(limit)) {
     return DEFAULT_RESULT_LIMIT;
   }
-
   if (!Number.isFinite(limit)) {
     throw new Error('Result limit must be a finite number');
   }
-
-  if (limit <= 0) {
-    return 0;
-  }
-
   const coerced = Math.floor(limit);
-  const positive = Math.max(coerced, 1);
-  return Math.min(positive, MAX_RESULT_LIMIT);
+  if (coerced <= 0) {
+    return DEFAULT_RESULT_LIMIT;
+  }
+  return Math.min(coerced, MAX_RESULT_LIMIT);
+}
+
+function buildFtsQuery(input: string): string {
+  const tokens = input
+    .split(/\s+/)
+    .map((token) => token.trim())
+    .filter(Boolean);
+  if (tokens.length === 0) {
+    return '';
+  }
+  return tokens
+    .map((token) => `"${token.replace(/"/g, '""')}"`)
+    .join(' AND ');
+}
+
+function computeConfidence(score: number): number {
+  const sanitized = Number.isFinite(score) ? score : Number.POSITIVE_INFINITY;
+  const normalized = Math.max(0, sanitized);
+  return 1 / (1 + normalized);
+}
+
+function updateSnippetHits(db: Database.Database, ids: number[]): void {
+  if (!ids.length) {
+    return;
+  }
+  const placeholders = ids.map(() => '?').join(', ');
+  db.prepare(`UPDATE snippets SET hits = hits + 1 WHERE id IN (${placeholders})`).run(...ids);
 }
 
 export async function semanticSearch(options: SemanticSearchOptions): Promise<SemanticSearchResult> {
@@ -117,192 +88,82 @@ export async function semanticSearch(options: SemanticSearchOptions): Promise<Se
   }
 
   const absoluteRoot = path.resolve(options.root);
-  const stats = await fs.stat(absoluteRoot);
-  if (!stats.isDirectory()) {
-    throw new Error(`Semantic search root must be a directory: ${absoluteRoot}`);
-  }
-
-  const dbPath = path.join(absoluteRoot, options.databaseName ?? DEFAULT_DB_FILENAME);
+  const databasePath = path.join(absoluteRoot, options.databaseName ?? DEFAULT_DB_FILENAME);
   const limit = normalizeResultLimit(options.limit);
 
-  const db = new Database(dbPath, { readonly: true });
+  const db = new Database(databasePath, { fileMustExist: true });
   try {
-    const totalChunkRow = db
-      .prepare('SELECT COUNT(*) as count FROM file_chunks')
-      .get() as { count: number } | undefined;
-    const totalChunks = totalChunkRow?.count ?? 0;
+    const totalRow = db.prepare('SELECT COUNT(*) as count FROM snippets').get() as { count?: number } | undefined;
+    const totalSnippets = totalRow?.count ?? 0;
 
-    if (totalChunks === 0) {
+    if (totalSnippets === 0) {
       return {
-        databasePath: dbPath,
-        embeddingModel: options.model ?? null,
-        totalChunks,
-        evaluatedChunks: 0,
-        results: []
+        databasePath,
+        totalSnippets,
+        evaluatedSnippets: 0,
+        results: [],
+        query: trimmedQuery
       };
     }
 
-    const availableModelRows = db
-      .prepare('SELECT DISTINCT embedding_model as embeddingModel FROM file_chunks')
-      .all() as { embeddingModel: string }[];
-    const availableModels = new Set(availableModelRows.map((row) => row.embeddingModel));
-    const requestedModel = options.model ?? (availableModels.size === 1 ? [...availableModels][0] : null);
-
-    if (!requestedModel) {
-      throw new Error(
-        `Multiple embedding models found (${[...availableModels].join(', ')}). Specify the desired model in the request.`
-      );
-    }
-
-    if (!availableModels.has(requestedModel)) {
-      throw new Error(
-        `No chunks indexed with embedding model '${requestedModel}'. Available models: ${[...availableModels].join(', ')}`
-      );
-    }
-
-    const chunkStmt = db.prepare(
-      `SELECT
-         id,
-         path,
-         chunk_index as chunkIndex,
-         content,
-         embedding,
-         embedding_model as embeddingModel,
-         byte_start as byteStart,
-         byte_end as byteEnd,
-         line_start as lineStart,
-         line_end as lineEnd
-       FROM file_chunks
-       WHERE embedding_model = ?`
+    const searchStmt = db.prepare(
+      `SELECT snippets.id as id,
+              snippets.file as file,
+              snippets.text as text,
+              snippets.start_line as startLine,
+              snippets.end_line as endLine,
+              bm25(snippets_fts) as score
+         FROM snippets_fts
+         JOIN snippets ON snippets_fts.rowid = snippets.id
+         WHERE snippets_fts MATCH ?
+         ORDER BY score ASC
+         LIMIT ?`
     );
 
-    const fileContentStmt = db.prepare('SELECT content FROM files WHERE path = ?');
-    const fileCache = new Map<string, FileCacheEntry>();
-
-    const getFileEntry = (filePath: string): FileCacheEntry => {
-      const cached = fileCache.get(filePath);
-      if (cached) {
-        return cached;
-      }
-
-      const row = fileContentStmt.get(filePath) as { content: string | null } | undefined;
-      const content = row?.content ?? null;
-      const lines = content ? content.split(/\r?\n/) : null;
-      const trimmed = content ? content.trim() : null;
-      const trimmedLines = trimmed ? trimmed.split(/\r?\n/) : null;
-      const entry: FileCacheEntry = {
-        content,
-        lines,
-        trimmed,
-        trimmedLines
-      };
-      fileCache.set(filePath, entry);
-      return entry;
-    };
-
-    const deriveMetadataFromContent = (
-      entry: FileCacheEntry,
-      snippet: string
-    ): { byteStart: number | null; byteEnd: number | null; lineStart: number | null; lineEnd: number | null } => {
-      if (!entry.trimmed) {
-        return { byteStart: null, byteEnd: null, lineStart: null, lineEnd: null };
-      }
-
-      const startIndex = entry.trimmed.indexOf(snippet);
-      if (startIndex === -1) {
-        return { byteStart: null, byteEnd: null, lineStart: null, lineEnd: null };
-      }
-
-      const endIndex = startIndex + snippet.length;
-      const byteStart = Buffer.byteLength(entry.trimmed.slice(0, startIndex), 'utf8');
-      const byteEnd = Buffer.byteLength(entry.trimmed.slice(0, endIndex), 'utf8');
-
-      const preSnippet = entry.trimmed.slice(0, startIndex);
-      const lineStart = preSnippet ? preSnippet.split('\n').length : 1;
-      const snippetLineCount = snippet ? snippet.split('\n').length : 1;
-      const lineEnd = lineStart + Math.max(0, snippetLineCount - 1);
-
-      return { byteStart, byteEnd, lineStart, lineEnd };
-    };
-
-    const extractContext = (
-      entry: FileCacheEntry,
-      startLine: number | null,
-      endLine: number | null
-    ): { before: string | null; after: string | null } => {
-      if (!entry.trimmedLines || startLine === null || endLine === null) {
-        return { before: null, after: null };
-      }
-
-      const beforeStart = Math.max(0, startLine - 1 - CONTEXT_LINE_PADDING);
-      const beforeEnd = Math.max(0, startLine - 1);
-      const afterStart = Math.min(entry.trimmedLines.length, endLine);
-      const afterEnd = Math.min(entry.trimmedLines.length, endLine + CONTEXT_LINE_PADDING);
-
-      const beforeLines = beforeEnd > beforeStart ? entry.trimmedLines.slice(beforeStart, beforeEnd) : [];
-      const afterLines = afterEnd > afterStart ? entry.trimmedLines.slice(afterStart, afterEnd) : [];
-
-      return {
-        before: beforeLines.length > 0 ? beforeLines.join('\n') : null,
-        after: afterLines.length > 0 ? afterLines.join('\n') : null
-      };
-    };
-
-    const [queryEmbedding] = await embedTexts([trimmedQuery], { model: requestedModel });
-
-    const topMatches: SemanticSearchMatch[] = [];
-    let evaluatedChunks = 0;
-
-    for (const row of chunkStmt.iterate(requestedModel) as Iterable<ChunkRow>) {
-      evaluatedChunks += 1;
-      const chunkEmbedding = bufferToFloat32Array(row.embedding);
-      const score = dotProduct(queryEmbedding, chunkEmbedding);
-      insertIntoTopMatches(
-        topMatches,
-        {
-          path: row.path,
-          chunkIndex: row.chunkIndex,
-          content: row.content,
-          score,
-          embeddingModel: row.embeddingModel,
-          byteStart: row.byteStart ?? null,
-          byteEnd: row.byteEnd ?? null,
-          lineStart: row.lineStart ?? null,
-          lineEnd: row.lineEnd ?? null,
-          contextBefore: null,
-          contextAfter: null
-        },
-        limit
-      );
+    const ftsQueryPrimary = buildFtsQuery(trimmedQuery);
+    if (!ftsQueryPrimary) {
+      throw new Error('Query must include searchable terms.');
     }
 
-    const results = limit > 0 ? [...topMatches].reverse() : [];
-
-    for (const match of results) {
-      const entry = getFileEntry(match.path);
-
-      const needsMetadataFallback =
-        match.byteStart === null || match.byteEnd === null || match.lineStart === null || match.lineEnd === null;
-
-      if (needsMetadataFallback) {
-        const derived = deriveMetadataFromContent(entry, match.content);
-        match.byteStart = match.byteStart ?? derived.byteStart;
-        match.byteEnd = match.byteEnd ?? derived.byteEnd;
-        match.lineStart = match.lineStart ?? derived.lineStart;
-        match.lineEnd = match.lineEnd ?? derived.lineEnd;
+    let rows: SnippetRow[] = [];
+    try {
+      rows = searchStmt.all(ftsQueryPrimary, limit) as SnippetRow[];
+    } catch (error) {
+      const fallbackQuery = `"${trimmedQuery.replace(/"/g, '""')}"`;
+      rows = searchStmt.all(fallbackQuery, limit) as SnippetRow[];
+      if (!rows.length) {
+        throw error instanceof Error
+          ? new Error(`Search failed: ${error.message}`)
+          : new Error(`Search failed: ${String(error)}`);
       }
+    }
 
-      const context = extractContext(entry, match.lineStart, match.lineEnd);
-      match.contextBefore = context.before;
-      match.contextAfter = context.after;
+    const matches: SemanticSearchMatch[] = rows.map((row) => {
+      const score = Number.isFinite(row.score) ? row.score : Number(row.score);
+      return {
+        file: row.file,
+        snippetId: row.id,
+        score,
+        confidence: computeConfidence(score),
+        text: row.text,
+        startLine: row.startLine,
+        endLine: row.endLine
+      };
+    });
+
+    if (matches.length) {
+      updateSnippetHits(
+        db,
+        matches.map((match) => match.snippetId)
+      );
     }
 
     return {
-      databasePath: dbPath,
-      embeddingModel: requestedModel,
-      totalChunks,
-      evaluatedChunks,
-      results
+      databasePath,
+      totalSnippets,
+      evaluatedSnippets: matches.length,
+      results: matches,
+      query: trimmedQuery
     };
   } finally {
     db.close();

--- a/src/status.ts
+++ b/src/status.ts
@@ -1,146 +1,108 @@
 import Database from 'better-sqlite3';
+import { execFile } from 'node:child_process';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
+import { promisify } from 'node:util';
 
 import { DEFAULT_DB_FILENAME } from './constants.js';
+
+const execFileAsync = promisify(execFile);
 
 export interface IndexStatusOptions {
   root: string;
   databaseName?: string;
-  historyLimit?: number;
-}
-
-export interface IndexStatusIngestion {
-  id: string;
-  root: string;
-  startedAt: number;
-  finishedAt: number;
-  durationMs: number;
-  fileCount: number;
-  skippedCount: number;
-  deletedCount: number;
 }
 
 export interface IndexStatusResult {
   databasePath: string;
   databaseExists: boolean;
   databaseSizeBytes: number | null;
-  totalFiles: number;
-  totalChunks: number;
-  embeddingModels: string[];
-  totalGraphNodes: number;
-  totalGraphEdges: number;
-  latestIngestion: IndexStatusIngestion | null;
-  recentIngestions: IndexStatusIngestion[];
+  totalSymbols: number;
+  totalSnippets: number;
+  lastIndexedAt: number | null;
+  indexedCommitSha: string | null;
+  currentCommitSha: string | null;
+  isStale: boolean;
 }
 
-interface RawIngestionRow {
-  id: string;
-  root: string;
-  startedAt: number;
-  finishedAt: number;
-  fileCount: number;
-  skippedCount: number;
-  deletedCount: number;
-}
-
-const DEFAULT_HISTORY_LIMIT = 5;
-
-function mapIngestionRow(row: RawIngestionRow): IndexStatusIngestion {
-  return {
-    ...row,
-    durationMs: row.finishedAt - row.startedAt
-  };
+async function resolveGitCommitSha(root: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync('git', ['rev-parse', 'HEAD'], { cwd: root });
+    const sha = stdout.trim();
+    return sha ? sha : null;
+  } catch {
+    return null;
+  }
 }
 
 export async function getIndexStatus(options: IndexStatusOptions): Promise<IndexStatusResult> {
   const absoluteRoot = path.resolve(options.root);
-  const dbPath = path.join(absoluteRoot, options.databaseName ?? DEFAULT_DB_FILENAME);
+  const databasePath = path.join(absoluteRoot, options.databaseName ?? DEFAULT_DB_FILENAME);
 
   let databaseExists = false;
   let databaseSizeBytes: number | null = null;
 
   try {
-    const stats = await fs.stat(dbPath);
+    const stats = await fs.stat(databasePath);
     if (!stats.isFile()) {
-      throw new Error(`Expected SQLite database file at ${dbPath}, but found a different file type.`);
+      throw new Error(`Expected SQLite database file at ${databasePath}, but found a different file type.`);
     }
     databaseExists = true;
     databaseSizeBytes = stats.size;
   } catch (error) {
     const code =
-      error && typeof error === 'object' && 'code' in error
-        ? (error as { code?: string }).code
-        : undefined;
+      error && typeof error === 'object' && 'code' in error ? (error as { code?: string }).code : undefined;
     if (code !== 'ENOENT') {
       throw error instanceof Error
-        ? new Error(`Failed to stat database at ${dbPath}: ${error.message}`)
-        : new Error(`Failed to stat database at ${dbPath}: ${String(error)}`);
+        ? new Error(`Failed to stat database at ${databasePath}: ${error.message}`)
+        : new Error(`Failed to stat database at ${databasePath}: ${String(error)}`);
     }
   }
 
   if (!databaseExists) {
+    const currentCommitSha = await resolveGitCommitSha(absoluteRoot);
     return {
-      databasePath: dbPath,
+      databasePath,
       databaseExists: false,
       databaseSizeBytes: null,
-      totalFiles: 0,
-      totalChunks: 0,
-      embeddingModels: [],
-      totalGraphNodes: 0,
-      totalGraphEdges: 0,
-      latestIngestion: null,
-      recentIngestions: []
+      totalSymbols: 0,
+      totalSnippets: 0,
+      lastIndexedAt: null,
+      indexedCommitSha: null,
+      currentCommitSha,
+      isStale: true
     };
   }
 
-  const db = new Database(dbPath, { readonly: true, fileMustExist: true });
+  const db = new Database(databasePath, { readonly: true, fileMustExist: true });
   try {
-    const totalFilesRow = db.prepare('SELECT COUNT(*) as count FROM files').get() as { count?: number } | undefined;
-    const totalChunksRow = db.prepare('SELECT COUNT(*) as count FROM file_chunks').get() as { count?: number } | undefined;
-    const totalGraphNodesRow = db
-      .prepare('SELECT COUNT(*) as count FROM code_graph_nodes')
+    const symbolCountRow = db
+      .prepare('SELECT COUNT(*) as count FROM symbols')
       .get() as { count?: number } | undefined;
-    const totalGraphEdgesRow = db
-      .prepare('SELECT COUNT(*) as count FROM code_graph_edges')
+    const snippetCountRow = db
+      .prepare('SELECT COUNT(*) as count FROM snippets')
       .get() as { count?: number } | undefined;
+    const metaRow = db
+      .prepare('SELECT commit_sha as commitSha, indexed_at as indexedAt FROM meta WHERE id = 1')
+      .get() as { commitSha?: string | null; indexedAt?: number | null } | undefined;
 
-    const embeddingRows = db
-      .prepare('SELECT DISTINCT embedding_model as embeddingModel FROM file_chunks ORDER BY embedding_model ASC')
-      .all() as { embeddingModel: string }[];
-
-    const historyLimit = options.historyLimit ?? DEFAULT_HISTORY_LIMIT;
-    const ingestionRows = historyLimit > 0
-      ? (db
-          .prepare(
-            `SELECT
-               id as id,
-               root as root,
-               started_at as startedAt,
-               finished_at as finishedAt,
-               file_count as fileCount,
-               skipped_count as skippedCount,
-               deleted_count as deletedCount
-             FROM ingestions
-             ORDER BY finished_at DESC
-             LIMIT ?`
-          )
-          .all(historyLimit) as RawIngestionRow[])
-      : [];
-
-    const ingestions = ingestionRows.map(mapIngestionRow);
+    const indexedCommitSha = metaRow?.commitSha ?? null;
+    const lastIndexedAt = metaRow?.indexedAt ?? null;
+    const currentCommitSha = await resolveGitCommitSha(absoluteRoot);
+    const isStale = Boolean(
+      indexedCommitSha && currentCommitSha && indexedCommitSha !== currentCommitSha
+    );
 
     return {
-      databasePath: dbPath,
+      databasePath,
       databaseExists: true,
       databaseSizeBytes,
-      totalFiles: totalFilesRow?.count ?? 0,
-      totalChunks: totalChunksRow?.count ?? 0,
-      embeddingModels: embeddingRows.map((row) => row.embeddingModel),
-      totalGraphNodes: totalGraphNodesRow?.count ?? 0,
-      totalGraphEdges: totalGraphEdgesRow?.count ?? 0,
-      latestIngestion: ingestions[0] ?? null,
-      recentIngestions: ingestions
+      totalSymbols: symbolCountRow?.count ?? 0,
+      totalSnippets: snippetCountRow?.count ?? 0,
+      lastIndexedAt,
+      indexedCommitSha,
+      currentCommitSha,
+      isStale
     };
   } finally {
     db.close();


### PR DESCRIPTION
## Summary
- migrate ingestion to populate symbols/snippets/meta tables while preserving hit counters and commit metadata
- replace embedding-based search and bundles with SQLite-driven FTS queries and token-budgeted context assembly
- expose auto code lookup routing plus clearer index status reporting based on commit freshness

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbe91c13d88333a0047f23d6ef7e06