### PR TITLE
Isolate index storage per workspace identity

### DIFF
--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -136,7 +136,7 @@ The implementation supports the suggested configuration:
 [mcp_servers.index_mcp]
 command = "/Users/mohammedsayf/Desktop/index-mcp/start.sh"
 env = {
-  INDEX_MCP_DB = "/Users/mohammedsayf/Desktop/index-mcp/.mcp-index.sqlite",
+  INDEX_MCP_DB = "/Users/mohammedsayf/.index-mcp/indexes/custom.sqlite",
   INDEX_MCP_BUDGET_TOKENS = "3000"
 }
 startup_timeout_ms = 120000
@@ -144,8 +144,11 @@ startup_timeout_ms = 120000
 
 **Environment variables added:**
 - `INDEX_MCP_BUDGET_TOKENS`: Default token budget for context bundles (default: 3000)
+- `INDEX_MCP_DB_DIR`: Optional base directory for managed index files (defaults to `~/.index-mcp/indexes`).
+- `INDEX_MCP_DB`: Optional absolute path override for the SQLite database (takes precedence over `INDEX_MCP_DB_DIR`).
+- `MCP_WORKSPACE_ID`, `WORKSPACE_ID`, `GITHUB_REPOSITORY`, `CI_PROJECT_PATH`, and other workspace/repository identifiers (along with their `x-` header equivalents) are now consumed to derive a stable workspace identity so concurrent agents indexing different repos do not share a database. Git remotes/worktrees are used as a fallback when metadata is absent, and the resolved components are persisted in `index-manifest.json` alongside the database.
 
-**Note:** `INDEX_MCP_DB` is not currently used as the database is always stored at the repository root as `.mcp-index.sqlite`. This could be enhanced in the future.
+`ingest_codebase` responses include a `storage` object that reports the resolved directory, source, root hash, identity hash, and the identity components so orchestrators can audit and cache per-repo indexes safely.
 
 ## Current Practices Maintained ✅
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # index-mcp
 
-An MCP (Model Context Protocol) server that scans a source-code workspace and builds a searchable SQLite index (`.mcp-index.sqlite` by default) in the project root. The index stores file metadata, hashes, and optionally file contents so MCP-compatible clients can perform fast lookups, semantic search, and graph exploration.
+An MCP (Model Context Protocol) server that scans a source-code workspace and builds a searchable SQLite index managed outside the working tree. By default the server creates `.mcp-index.sqlite` inside a hashed directory under `~/.index-mcp/indexes/`, keeping the repository clean while still storing file metadata, hashes, and optional file contents for fast lookups, semantic search, and graph exploration.
 
 **New in this version:** Context budget control and hotness tracking to prevent overwhelming LLMs with excessive context. Only small, focused bundles are sent based on actual usage patterns.
 
@@ -78,6 +78,20 @@ You can also pass flags through `npm run dev` (e.g. `npm run dev -- --watch`). U
 - `--watch-database=<filename>` – Choose a custom SQLite filename.
 - `--watch-no-initial` – Skip the initial full ingest.
 - `--watch-quiet` – Silence watcher logs.
+
+## Index storage directory
+
+Index files are persisted outside the repository in a managed cache tree:
+
+- Each workspace is resolved to an **identity** derived from the absolute root, supported metadata (headers/env vars such as `x-workspace-id`, `MCP_WORKSPACE_ID`, `GITHUB_REPOSITORY`), and Git remotes/worktree info when available. The root hash remains the first directory segment, and unique identities nest underneath it (`~/.index-mcp/indexes/<rootHash>/<identityHash>/`).
+- Every identity directory stores an `index-manifest.json` with the resolved components so operators can trace which repo/workspace produced the database. Subsequent tool calls automatically reuse the same namespace, preventing agents that work across multiple repositories from mixing context.
+- The file name defaults to `.mcp-index.sqlite`, but you can supply a custom name via tool inputs or `--watch-database`. The value is sanitized to a file name before use.
+- Set `INDEX_MCP_DB_DIR` to override the base directory (for example to place indexes on faster storage).
+- Set `INDEX_MCP_DB` to override the database file path entirely (useful for single-tenant deployments). When this is provided the server attempts to create the parent directory and fails the request if it is not writable.
+
+If neither environment variable is set and the home directory is unavailable, the server falls back to `${TMPDIR}/index-mcp/indexes/`. Only when all candidates fail will it place the database inside the workspace, and a warning is logged in that case. When the path is fully overridden via `INDEX_MCP_DB`, the identity manifest is not written (the operator is expected to manage the target directory).
+
+Calls to `ingest_codebase` include a `storage` block in the structured response so agents can audit which namespace was used (directory, source, root hash, identity hash, and the individual identity components).
 
 When embedding the server in another process, call `await runCleanup()` from `src/cleanup.ts` before exit so watchers, transports, and embedding pipelines shut down cleanly.
 

--- a/agents.md
+++ b/agents.md
@@ -45,7 +45,7 @@ This document explains how to run and use the **index-mcp** server with the Code
 
 ## 1. Overview
 
-- **Purpose:** Index a codebase into a root-level SQLite database (`.mcp-index.sqlite`) so agents can perform fast metadata/content queries.
+- **Purpose:** Index a codebase into a managed SQLite database (default `.mcp-index.sqlite` stored under `~/.index-mcp/indexes/<rootHash>/<identityHash>/`) so agents can perform fast metadata/content queries without polluting the workspace or mixing data between repositories.
 - **Primary tool:** `ingest_codebase` – scans files, stores hashes, metadata, and optionally UTF-8 content.
 - **Supporting prompt:** `indexing_guidance` – returns reminders about when to run the ingestor.
 - **Helper script:** `start.sh` – rebuilds the TypeScript bundles, refreshes the native addon, spins up the local HTTP/SSE backend, and launches the stdio MCP server.
@@ -103,9 +103,15 @@ The sidecar backend (`src/local-backend/server.ts`) exposes an HTTP/SSE surface 
 - `--watch-debounce <ms>` — adjust the debounce window before an ingest is triggered (default 500 ms, minimum 50 ms).
 - `--watch-no-initial` — skip the initial full ingest when the watcher starts.
 - `--watch-quiet` — silence watcher log output.
-- `--watch-database <filename>` — customize the SQLite filename instead of `.mcp-index.sqlite`.
+- `--watch-database <filename>` — customize the SQLite filename stored in the managed index directory (defaults to `.mcp-index.sqlite`).
 
 These align with the `startIngestWatcher` options and make it easy to tune incremental ingest behaviour for larger projects.
+
+### Workspace identity & storage namespace
+
+- The server derives a stable workspace identity from the absolute root, Git remotes/worktree metadata, and any caller-provided identifiers (headers like `x-workspace-id`, `x-repository`, `x-github-repository`; env vars such as `MCP_WORKSPACE_ID`, `WORKSPACE_ID`, `GITHUB_REPOSITORY`, `CI_PROJECT_PATH`). Each unique identity is mapped to `~/.index-mcp/indexes/<rootHash>/<identityHash>/`.
+- Every namespace directory gets an `index-manifest.json` so operators can audit which components produced a given database. Managed tools automatically reuse the same manifest to avoid mixing indexes when agents move between repos.
+- When `INDEX_MCP_DB` explicitly overrides the database path the manifest is skipped—manage that directory yourself if you need multi-tenant isolation.
 
 ## 5. Codex CLI Configuration
 
@@ -145,7 +151,7 @@ Environment variables scoped in the `env` table support both the `INDEX_MCP_*` n
 | Name             | Type  | Description |
 |------------------|-------|-------------|
 | `code_lookup`     | Tool  | Unified entry point that auto-routes queries to semantic search, context bundles, or graph neighbors so Codex doesn’t need to pick a specialist tool manually. |
-| `ingest_codebase` | Tool  | Walks a directory, stores metadata + optional UTF-8 content for each file in `.mcp-index.sqlite`, and prunes deleted entries. Accepts optional glob include/exclude, custom database name, file-size limits, and `storeFileContent` toggle. |
+| `ingest_codebase` | Tool  | Walks a directory, stores metadata + optional UTF-8 content in the managed SQLite database (default filename `.mcp-index.sqlite`), and prunes deleted entries. Accepts optional glob include/exclude, custom database name, file-size limits, and `storeFileContent` toggle. Structured output includes a `storage` block with the resolved namespace (directory/source/hashes/identity components). |
 | `semantic_search` | Tool  | Embedding-powered retrieval across stored `file_chunks` for natural-language or code queries. Returns scored snippets along with byte offsets, line spans, and nearby context so agents can understand matches without opening the source file. |
 | `graph_neighbors` | Tool  | Query GraphRAG nodes/edges produced during ingestion to inspect imports and call relationships. |
 | `context_bundle` | Tool  | Package file metadata, definitions, related edges, and representative snippets into a single response so agents can bootstrap context quickly. |
@@ -182,9 +188,9 @@ If your client does not yet support MCP prompts, call `indexing_guidance_tool` t
    - `mode="graph"` plus `symbol`/`node` -> graph neighbor exploration.
 4. *(Optional)* **Run the watcher:** `npm run watch` keeps the database fresh by triggering incremental ingests when files change.
 5. **Use specialist tools** directly when you need their structured responses without routing (e.g. `index_status` or `info`).
-6. **Re-index after edits:** call `ingest_codebase` again (or rely on the watcher) so `.mcp-index.sqlite` reflects the latest changes.
+6. **Re-index after edits:** call `ingest_codebase` again (or rely on the watcher) so the managed SQLite index reflects the latest changes.
 7. **Shut down cleanly:** `await runCleanup()` (or rely on the CLI’s built-in signal handlers) when stopping the server so the asynchronous teardown can finish terminating watchers, closing transports, and draining embedding/native caches before the process exits.
-8. **Optional inspection:** use `sqlite3 .mcp-index.sqlite` to run ad-hoc queries if needed.
+8. **Optional inspection:** use `sqlite3 $(ingest_codebase.databasePath)` (or the resolved path under `~/.index-mcp/indexes/<rootHash>/<identityHash>/`) to run ad-hoc queries if needed.
 
 ## 8. Database Schema (summary)
 
@@ -229,7 +235,7 @@ If your client does not yet support MCP prompts, call `indexing_guidance_tool` t
 | `root`             | none (required)       | Path to scan. Relative paths resolve against the server’s working directory. |
 | `include`          | `["**/*"]`           | Glob patterns to include (fast-glob syntax). |
 | `exclude`          | Several defaults      | Includes VCS folders, `node_modules`, `dist`, and the database itself. You can pass extra patterns. |
-| `databaseName`     | `.mcp-index.sqlite`   | File created at the root. |
+| `databaseName`     | `.mcp-index.sqlite`   | File name stored in the managed index directory (value is sanitized to a base name). |
 | `maxFileSizeBytes` | `8388608` (8 MiB)     | Larger files are skipped and logged in `skipped`. |
 | `storeFileContent` | `true`                | If `false`, only metadata is stored. Binary detection uses a null-byte heuristic. |
 | `contentSanitizer` | `undefined`           | Optional `{ module, exportName?, options? }` descriptor that loads a sanitizer to redact or strip contents before storage. |

--- a/src/context-bundle.ts
+++ b/src/context-bundle.ts
@@ -2,7 +2,8 @@ import Database from 'better-sqlite3';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
-import { DEFAULT_DB_FILENAME } from './constants.js';
+import { resolveIndexDatabasePath } from './index-storage.js';
+import type { WorkspaceIdentity } from './workspace-identity.js';
 
 export interface ContextBundleSymbolSelector {
   name: string;
@@ -17,6 +18,7 @@ export interface ContextBundleOptions {
   maxSnippets?: number;
   maxNeighbors?: number;
   budgetTokens?: number;
+  workspaceIdentity?: WorkspaceIdentity;
 }
 
 export interface BundleFileMetadata {
@@ -337,7 +339,11 @@ export async function getContextBundle(options: ContextBundleOptions): Promise<C
     throw new Error(`Context bundle root must be a directory: ${absoluteRoot}`);
   }
 
-  const databasePath = path.join(absoluteRoot, options.databaseName ?? DEFAULT_DB_FILENAME);
+  const { databasePath } = resolveIndexDatabasePath(
+    absoluteRoot,
+    options.databaseName,
+    options.workspaceIdentity
+  );
   const db = new Database(databasePath, { fileMustExist: true });
 
   try {

--- a/src/eviction.ts
+++ b/src/eviction.ts
@@ -2,12 +2,14 @@ import Database from 'better-sqlite3';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
-import { DEFAULT_DB_FILENAME } from './constants.js';
+import { resolveIndexDatabasePath } from './index-storage.js';
+import type { WorkspaceIdentity } from './workspace-identity.js';
 
 export interface EvictionOptions {
   root: string;
   databaseName?: string;
   maxSizeBytes?: number;
+  workspaceIdentity?: WorkspaceIdentity;
 }
 
 export interface EvictionResult {
@@ -23,7 +25,11 @@ const DEFAULT_MAX_SIZE_BYTES = 150 * 1024 * 1024; // 150 MB
 
 export async function evictLeastUsed(options: EvictionOptions): Promise<EvictionResult> {
   const absoluteRoot = path.resolve(options.root);
-  const dbPath = path.join(absoluteRoot, options.databaseName ?? DEFAULT_DB_FILENAME);
+  const { databasePath: dbPath } = resolveIndexDatabasePath(
+    absoluteRoot,
+    options.databaseName,
+    options.workspaceIdentity
+  );
   const maxSizeBytes = options.maxSizeBytes ?? DEFAULT_MAX_SIZE_BYTES;
 
   const statsBefore = await fs.stat(dbPath);

--- a/src/graph-query.ts
+++ b/src/graph-query.ts
@@ -2,7 +2,8 @@ import Database from 'better-sqlite3';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
-import { DEFAULT_DB_FILENAME } from './constants.js';
+import { resolveIndexDatabasePath } from './index-storage.js';
+import type { WorkspaceIdentity } from './workspace-identity.js';
 
 export type GraphNeighborDirection = 'incoming' | 'outgoing' | 'both';
 
@@ -19,6 +20,7 @@ export interface GraphNeighborsOptions {
   node: GraphNodeDescriptor;
   direction?: GraphNeighborDirection;
   limit?: number;
+  workspaceIdentity?: WorkspaceIdentity;
 }
 
 export interface GraphNodeSummary {
@@ -94,7 +96,11 @@ export async function graphNeighbors(options: GraphNeighborsOptions): Promise<Gr
     throw new Error(`Graph query root must be a directory: ${absoluteRoot}`);
   }
 
-  const dbPath = path.join(absoluteRoot, options.databaseName ?? DEFAULT_DB_FILENAME);
+  const { databasePath: dbPath } = resolveIndexDatabasePath(
+    absoluteRoot,
+    options.databaseName,
+    options.workspaceIdentity
+  );
   const db = new Database(dbPath, { readonly: true });
 
   try {

--- a/src/index-storage.ts
+++ b/src/index-storage.ts
@@ -1,0 +1,305 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { DEFAULT_DB_FILENAME } from './constants.js';
+import { createLogger } from './logger.js';
+import type { WorkspaceIdentity, WorkspaceIdentityComponent } from './workspace-identity.js';
+
+export type IndexStorageSource =
+  | 'INDEX_MCP_DB'
+  | 'INDEX_MCP_DB_DIR'
+  | 'home'
+  | 'tmp'
+  | 'workspace';
+
+export interface IndexStorageResolution {
+  readonly databasePath: string;
+  readonly storageDirectory: string;
+  readonly source: IndexStorageSource;
+  readonly rootHash: string;
+  readonly identityHash: string;
+  readonly identityComponents: WorkspaceIdentityComponent[];
+}
+
+interface DirectoryCandidate {
+  readonly path: string;
+  readonly source: Exclude<IndexStorageSource, 'INDEX_MCP_DB' | 'workspace'>;
+}
+
+const log = createLogger('index-storage');
+
+const INDEX_MANIFEST_FILENAME = 'index-manifest.json';
+
+const recordedWarnings = new Set<string>();
+
+function warnOnce(key: string, message: string, context: Record<string, unknown>): void {
+  if (recordedWarnings.has(key)) {
+    return;
+  }
+  recordedWarnings.add(key);
+  log.warn(context, message);
+}
+
+function toAbsolutePath(candidate: string): string {
+  return path.isAbsolute(candidate) ? candidate : path.resolve(candidate);
+}
+
+function sanitizeDatabaseName(candidate: string | undefined): string {
+  const trimmed = candidate?.trim();
+  if (!trimmed) {
+    return DEFAULT_DB_FILENAME;
+  }
+  const basename = path.basename(trimmed);
+  if (!basename || basename === '.' || basename === '..') {
+    return DEFAULT_DB_FILENAME;
+  }
+  return basename;
+}
+
+function ensureDirectory(directoryPath: string, context: Record<string, unknown>): boolean {
+  try {
+    const stats = fs.statSync(directoryPath);
+    if (!stats.isDirectory()) {
+      warnOnce(
+        `${directoryPath}:not-directory`,
+        '[index-mcp] Index storage path exists but is not a directory; skipping candidate.',
+        { ...context, directory: directoryPath }
+      );
+      return false;
+    }
+  } catch (error) {
+    const maybeErrno = error as NodeJS.ErrnoException;
+    if (maybeErrno?.code && maybeErrno.code !== 'ENOENT') {
+      warnOnce(
+        `${directoryPath}:stat:${maybeErrno.code}`,
+        '[index-mcp] Unable to inspect index storage directory; skipping candidate.',
+        { ...context, directory: directoryPath, error: maybeErrno.message, code: maybeErrno.code }
+      );
+      return false;
+    }
+  }
+
+  try {
+    fs.mkdirSync(directoryPath, { recursive: true });
+  } catch (error) {
+    const maybeErrno = error as NodeJS.ErrnoException;
+    warnOnce(
+      `${directoryPath}:mkdir:${maybeErrno?.code ?? 'unknown'}`,
+      '[index-mcp] Unable to create index storage directory; skipping candidate.',
+      { ...context, directory: directoryPath, error: maybeErrno?.message, code: maybeErrno?.code }
+    );
+    return false;
+  }
+
+  try {
+    fs.accessSync(directoryPath, fs.constants.W_OK);
+  } catch (error) {
+    const maybeErrno = error as NodeJS.ErrnoException;
+    warnOnce(
+      `${directoryPath}:access:${maybeErrno?.code ?? 'unknown'}`,
+      '[index-mcp] Index storage directory is not writable; skipping candidate.',
+      { ...context, directory: directoryPath, error: maybeErrno?.message, code: maybeErrno?.code }
+    );
+    return false;
+  }
+
+  return true;
+}
+
+function computeRootHash(root: string): string {
+  return crypto.createHash('sha256').update(root).digest('hex').slice(0, 16);
+}
+
+function coalesceIdentityComponents(
+  absoluteRoot: string,
+  identity: WorkspaceIdentity | undefined
+): WorkspaceIdentityComponent[] {
+  const components: WorkspaceIdentityComponent[] = [];
+  const seenValues = new Set<string>();
+
+  const push = (component: WorkspaceIdentityComponent) => {
+    const normalizedValue = component.value.trim();
+    if (!normalizedValue || normalizedValue.length === 0) {
+      return;
+    }
+    if (seenValues.has(normalizedValue)) {
+      return;
+    }
+    seenValues.add(normalizedValue);
+    components.push({ source: component.source, value: normalizedValue });
+  };
+
+  push({ source: 'root', value: absoluteRoot });
+
+  if (identity) {
+    for (const component of identity.components) {
+      if (!component || typeof component.value !== 'string') {
+        continue;
+      }
+      const source = component.source || 'unknown';
+      push({ source, value: component.value });
+    }
+  }
+
+  return components;
+}
+
+function computeIdentityHash(
+  components: WorkspaceIdentityComponent[],
+  rootHash: string
+): string {
+  if (components.length <= 1) {
+    return rootHash;
+  }
+
+  const serialized = components.map((component) => `${component.source}:${component.value}`).join('\n');
+  return crypto.createHash('sha256').update(serialized).digest('hex').slice(0, 16);
+}
+
+interface IndexManifest {
+  readonly version: 1;
+  readonly root: string;
+  readonly rootHash: string;
+  readonly identityHash: string;
+  readonly components: WorkspaceIdentityComponent[];
+  readonly updatedAt: string;
+}
+
+function readManifest(filePath: string): IndexManifest | null {
+  try {
+    const raw = fs.readFileSync(filePath, 'utf8');
+    const parsed = JSON.parse(raw) as IndexManifest;
+    if (parsed && parsed.version === 1 && Array.isArray(parsed.components)) {
+      return parsed;
+    }
+  } catch {
+    // ignore malformed or missing manifest files
+  }
+  return null;
+}
+
+function writeManifest(directory: string, manifest: IndexManifest): void {
+  const manifestPath = path.join(directory, INDEX_MANIFEST_FILENAME);
+  const existing = readManifest(manifestPath);
+  if (existing) {
+    const unchanged =
+      existing.identityHash === manifest.identityHash &&
+      existing.root === manifest.root &&
+      existing.rootHash === manifest.rootHash &&
+      existing.components.length === manifest.components.length &&
+      existing.components.every((component, index) => {
+        const candidate = manifest.components[index];
+        return component.source === candidate.source && component.value === candidate.value;
+      });
+    if (unchanged) {
+      return;
+    }
+  }
+
+  try {
+    fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+  } catch (error) {
+    log.warn({ directory, err: error }, '[index-mcp] Failed to write index storage manifest.');
+  }
+}
+
+function getDirectoryCandidates(): DirectoryCandidate[] {
+  const candidates: DirectoryCandidate[] = [];
+  const explicitDir = process.env.INDEX_MCP_DB_DIR?.trim();
+  if (explicitDir) {
+    candidates.push({ source: 'INDEX_MCP_DB_DIR', path: toAbsolutePath(explicitDir) });
+  }
+
+  const homeDir = os.homedir();
+  if (homeDir && homeDir.trim()) {
+    candidates.push({ source: 'home', path: path.join(homeDir, '.index-mcp', 'indexes') });
+  }
+
+  candidates.push({ source: 'tmp', path: path.join(os.tmpdir(), 'index-mcp', 'indexes') });
+
+  return candidates;
+}
+
+export function resolveIndexDatabasePath(
+  root: string,
+  databaseName?: string,
+  identity?: WorkspaceIdentity
+): IndexStorageResolution {
+  const absoluteRoot = path.resolve(root);
+  const normalizedName = sanitizeDatabaseName(databaseName);
+  const rootHash = computeRootHash(absoluteRoot);
+  const identityComponents = coalesceIdentityComponents(absoluteRoot, identity);
+  const identityHash = computeIdentityHash(identityComponents, rootHash);
+
+  const explicitPath = process.env.INDEX_MCP_DB?.trim();
+  if (explicitPath) {
+    const resolvedExplicit = toAbsolutePath(explicitPath);
+    const parentDirectory = path.dirname(resolvedExplicit);
+    const context = { source: 'INDEX_MCP_DB' as const };
+    if (!ensureDirectory(parentDirectory, context)) {
+      throw new Error(
+        `[index-mcp] INDEX_MCP_DB=${resolvedExplicit} is not usable; parent directory cannot be prepared.`
+      );
+    }
+    return {
+      databasePath: resolvedExplicit,
+      storageDirectory: parentDirectory,
+      source: 'INDEX_MCP_DB',
+      rootHash: 'explicit',
+      identityHash,
+      identityComponents
+    };
+  }
+
+  const candidates = getDirectoryCandidates();
+
+  for (const candidate of candidates) {
+    const context = { source: candidate.source };
+    if (!ensureDirectory(candidate.path, context)) {
+      continue;
+    }
+    const rootDirectory = path.join(candidate.path, rootHash);
+    if (!ensureDirectory(rootDirectory, { ...context, storageDirectory: rootDirectory })) {
+      continue;
+    }
+    const storageDirectory =
+      identityHash === rootHash ? rootDirectory : path.join(rootDirectory, identityHash);
+    if (!ensureDirectory(storageDirectory, { ...context, storageDirectory })) {
+      continue;
+    }
+    const databasePath = path.join(storageDirectory, normalizedName);
+    writeManifest(storageDirectory, {
+      version: 1,
+      root: absoluteRoot,
+      rootHash,
+      identityHash,
+      components: identityComponents,
+      updatedAt: new Date().toISOString()
+    });
+    return {
+      databasePath,
+      storageDirectory,
+      source: candidate.source,
+      rootHash,
+      identityHash,
+      identityComponents
+    };
+  }
+
+  const fallbackPath = path.join(absoluteRoot, normalizedName);
+  warnOnce(
+    `${absoluteRoot}:fallback`,
+    '[index-mcp] Falling back to storing index inside workspace root; all storage candidates failed.',
+    { root: absoluteRoot, databasePath: fallbackPath }
+  );
+  return {
+    databasePath: fallbackPath,
+    storageDirectory: absoluteRoot,
+    source: 'workspace',
+    rootHash,
+    identityHash,
+    identityComponents
+  };
+}

--- a/src/ingest.ts
+++ b/src/ingest.ts
@@ -10,7 +10,9 @@ import { promisify } from 'node:util';
 
 import { embedTexts, float32ArrayToBuffer, getDefaultEmbeddingModel } from './embedding.js';
 import { extractGraphMetadata } from './graph.js';
-import { DEFAULT_DB_FILENAME, DEFAULT_INCLUDE_GLOBS, DEFAULT_EXCLUDE_GLOBS } from './constants.js';
+import { DEFAULT_INCLUDE_GLOBS, DEFAULT_EXCLUDE_GLOBS } from './constants.js';
+import { resolveIndexDatabasePath, type IndexStorageSource } from './index-storage.js';
+import type { WorkspaceIdentity, WorkspaceIdentityComponent } from './workspace-identity.js';
 import { loadNativeModule } from './native/index.js';
 import type {
   NativeBatchAnalysisResult,
@@ -81,6 +83,7 @@ export interface IngestOptions {
   include?: string[];
   exclude?: string[];
   databaseName?: string;
+  workspaceIdentity?: WorkspaceIdentity;
   maxFileSizeBytes?: number;
   storeFileContent?: boolean;
   contentSanitizer?: ContentSanitizerSpec;
@@ -101,6 +104,13 @@ export interface SkippedFile {
 export interface IngestResult {
   root: string;
   databasePath: string;
+  storage: {
+    directory: string;
+    source: IndexStorageSource;
+    rootHash: string;
+    identityHash: string;
+    identityComponents: WorkspaceIdentityComponent[];
+  };
   databaseSizeBytes: number;
   ingestedFileCount: number;
   skipped: SkippedFile[];
@@ -751,7 +761,16 @@ function normalizeTargetPaths(root: string, paths?: string[]): string[] {
 }
 
 export async function ingestCodebase(options: IngestOptions): Promise<IngestResult> {
-  const databaseName = options.databaseName ?? DEFAULT_DB_FILENAME;
+  const absoluteRoot = path.resolve(options.root);
+  const {
+    databasePath,
+    storageDirectory,
+    source: storageSource,
+    rootHash,
+    identityHash,
+    identityComponents
+  } = resolveIndexDatabasePath(absoluteRoot, options.databaseName, options.workspaceIdentity);
+  const databaseName = path.basename(databasePath);
   const includeGlobs = options.include ?? DEFAULT_INCLUDE_GLOBS;
   const excludeGlobs = Array.from(
     new Set([
@@ -767,7 +786,6 @@ export async function ingestCodebase(options: IngestOptions): Promise<IngestResu
   const embeddingConfig = resolveEmbeddingDefaults(options.embedding);
   const graphConfig = resolveGraphDefaults(options.graph);
 
-  const absoluteRoot = path.resolve(options.root);
   const targetPaths = normalizeTargetPaths(absoluteRoot, options.paths);
   const usingTargetPaths = targetPaths.length > 0;
   const searchPatterns = usingTargetPaths ? targetPaths : includeGlobs;
@@ -776,10 +794,9 @@ export async function ingestCodebase(options: IngestOptions): Promise<IngestResu
     throw new Error(`Ingest root must be a directory: ${absoluteRoot}`);
   }
 
-  const dbPath = path.join(absoluteRoot, databaseName);
   const startTime = Date.now();
 
-  const db: DatabaseInstance = new Database(dbPath);
+  const db: DatabaseInstance = new Database(databasePath);
   try {
     ensureSchema(db);
 
@@ -1143,7 +1160,7 @@ export async function ingestCodebase(options: IngestOptions): Promise<IngestResu
 
     db.close();
 
-    let dbStats = await fs.stat(dbPath);
+    let dbStats = await fs.stat(databasePath);
     let evictionResult: { chunks: number; nodes: number } | undefined;
 
     // Check if eviction is needed
@@ -1155,7 +1172,8 @@ export async function ingestCodebase(options: IngestOptions): Promise<IngestResu
       const evicted = await evictLeastUsed({
         root: absoluteRoot,
         databaseName: databaseName,
-        maxSizeBytes: maxDatabaseSizeBytes
+        maxSizeBytes: maxDatabaseSizeBytes,
+        workspaceIdentity: options.workspaceIdentity
       });
       
       if (evicted.wasEvictionNeeded) {
@@ -1163,13 +1181,20 @@ export async function ingestCodebase(options: IngestOptions): Promise<IngestResu
           chunks: evicted.evictedChunks,
           nodes: evicted.evictedNodes
         };
-        dbStats = await fs.stat(dbPath);
+        dbStats = await fs.stat(databasePath);
       }
     }
 
     return {
       root: absoluteRoot,
-      databasePath: dbPath,
+      databasePath,
+      storage: {
+        directory: storageDirectory,
+        source: storageSource,
+        rootHash,
+        identityHash,
+        identityComponents
+      },
       databaseSizeBytes: dbStats.size,
       ingestedFileCount: files.length,
       skipped,

--- a/src/search.ts
+++ b/src/search.ts
@@ -3,7 +3,8 @@ import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
 import { bufferToFloat32Array, embedTexts } from './embedding.js';
-import { DEFAULT_DB_FILENAME } from './constants.js';
+import { resolveIndexDatabasePath } from './index-storage.js';
+import type { WorkspaceIdentity } from './workspace-identity.js';
 
 interface ChunkRow {
   id: string;
@@ -24,6 +25,7 @@ export interface SemanticSearchOptions {
   databaseName?: string;
   limit?: number;
   model?: string;
+  workspaceIdentity?: WorkspaceIdentity;
 }
 
 export interface SemanticSearchMatch {
@@ -176,7 +178,11 @@ export async function semanticSearch(options: SemanticSearchOptions): Promise<Se
     throw new Error(`Semantic search root must be a directory: ${absoluteRoot}`);
   }
 
-  const dbPath = path.join(absoluteRoot, options.databaseName ?? DEFAULT_DB_FILENAME);
+  const { databasePath: dbPath } = resolveIndexDatabasePath(
+    absoluteRoot,
+    options.databaseName,
+    options.workspaceIdentity
+  );
   const limit = normalizeResultLimit(options.limit);
 
   const db = new Database(dbPath, { fileMustExist: true });

--- a/src/server.ts
+++ b/src/server.ts
@@ -30,6 +30,7 @@ import { getIndexStatus } from './status.js';
 import { getContextBundle } from './context-bundle.js';
 import { registerRemoteServers } from './remote-proxy.js';
 import { getRepositoryTimeline } from './git-timeline.js';
+import { resolveWorkspaceIdentity } from './workspace-identity.js';
 
 function rethrowWithContext(toolName: string, error: unknown): never {
   if (error instanceof Error) {
@@ -126,7 +127,8 @@ const ingestToolJsonSchema = {
     },
     databaseName: {
       type: 'string',
-      description: 'Optional SQLite filename (aliases: database, database_path, db). Defaults to .mcp-index.sqlite.'
+      description:
+        'Optional SQLite filename (aliases: database, database_path, db). Defaults to .mcp-index.sqlite stored in the managed index directory.'
     },
     maxFileSizeBytes: {
       type: 'integer',
@@ -276,9 +278,21 @@ const skippedFileSchema = z.object({
   size: z.number().optional(),
   message: z.string().optional()
 });
+const storageSourceSchema = z.enum(['INDEX_MCP_DB', 'INDEX_MCP_DB_DIR', 'home', 'tmp', 'workspace']);
+const identityComponentSchema = z.object({
+  source: z.string(),
+  value: z.string()
+});
 const ingestToolOutputShape = {
   root: z.string(),
   databasePath: z.string(),
+  storage: z.object({
+    directory: z.string(),
+    source: storageSourceSchema,
+    rootHash: z.string(),
+    identityHash: z.string(),
+    identityComponents: z.array(identityComponentSchema)
+  }),
   databaseSizeBytes: z.number(),
   ingestedFileCount: z.number(),
   skipped: z.array(skippedFileSchema),
@@ -481,7 +495,8 @@ const contextBundleJsonSchema = {
     },
     databaseName: {
       type: 'string',
-      description: 'Optional SQLite filename (aliases: database, database_path, db). Defaults to .mcp-index.sqlite.'
+      description:
+        'Optional SQLite filename (aliases: database, database_path, db). Defaults to .mcp-index.sqlite stored in the managed index directory.'
     },
     file: {
       type: 'string',
@@ -716,7 +731,8 @@ const codeLookupJsonSchema = {
     },
     databaseName: {
       type: 'string',
-      description: 'Optional SQLite filename (aliases: database, database_path, db). Defaults to .mcp-index.sqlite.'
+      description:
+        'Optional SQLite filename (aliases: database, database_path, db). Defaults to .mcp-index.sqlite stored in the managed index directory.'
     },
     model: {
       type: 'string',
@@ -1017,7 +1033,8 @@ const indexStatusJsonSchema = {
     },
     databaseName: {
       type: 'string',
-      description: 'Optional SQLite filename (aliases: database, database_path, db). Defaults to .mcp-index.sqlite.'
+      description:
+        'Optional SQLite filename (aliases: database, database_path, db). Defaults to .mcp-index.sqlite stored in the managed index directory.'
     },
     historyLimit: {
       type: 'integer',
@@ -1182,11 +1199,13 @@ async function main() {
     const watchDatabase = cli.values['watch-database'] as string | undefined;
     const runInitial = cli.values['watch-no-initial'] ? false : true;
     const quiet = cli.values['watch-quiet'] ?? false;
+    const watchIdentity = resolveWorkspaceIdentity(watchRoot, { env: process.env });
 
     try {
       watcherHandle = await startIngestWatcher({
         root: watchRoot,
         databaseName: watchDatabase,
+        workspaceIdentity: watchIdentity,
         debounceMs,
         runInitial,
         quiet: quiet === true,
@@ -1230,11 +1249,13 @@ async function main() {
         const parsedInput = ingestToolSchema.parse(normalizedInput);
         const context = createRootResolutionContext(extra);
         const resolvedRoot = resolveRootPath(parsedInput.root, context);
+        const workspaceIdentity = resolveWorkspaceIdentity(resolvedRoot, context);
         const resolvedPaths = resolveIngestPaths(resolvedRoot, context, parsedInput.paths);
         const ingestInput = {
           ...parsedInput,
           root: resolvedRoot,
-          paths: resolvedPaths.length ? resolvedPaths : undefined
+          paths: resolvedPaths.length ? resolvedPaths : undefined,
+          workspaceIdentity
         };
         const result = ingestToolOutputSchema.parse(await ingestCodebase(ingestInput));
 
@@ -1244,7 +1265,7 @@ async function main() {
               type: 'text',
               text: `Indexed ${result.ingestedFileCount} files in ${(result.durationMs / 1000).toFixed(
                 2
-              )}s. Database: ${result.databasePath}. Re-run ingest_codebase after any edits to keep the index fresh.`
+              )}s. Database: ${result.databasePath} (namespace ${result.storage.identityHash}). Re-run ingest_codebase after any edits to keep the index fresh.`
             }
           ],
           structuredContent: result
@@ -1272,6 +1293,7 @@ async function main() {
         const parsedInput = codeLookupInputSchema.parse(normalizedInput);
         const context = createRootResolutionContext(extra);
         const resolvedRoot = resolveRootPath(parsedInput.root, context);
+        const workspaceIdentity = resolveWorkspaceIdentity(resolvedRoot, context);
 
         const resolvedMode =
           parsedInput.mode ?? (parsedInput.query ? 'search' : parsedInput.file ? 'bundle' : 'graph');
@@ -1285,7 +1307,8 @@ async function main() {
             query: parsedInput.query,
             databaseName: parsedInput.databaseName,
             limit: parsedInput.limit,
-            model: parsedInput.model
+            model: parsedInput.model,
+            workspaceIdentity
           };
           const searchResult = semanticSearchOutputSchema.parse(await semanticSearch(searchInput));
           const modelDescriptor = searchResult.embeddingModel ? `model ${searchResult.embeddingModel}` : 'stored embeddings';
@@ -1321,7 +1344,8 @@ async function main() {
             file: parsedInput.file,
             symbol: parsedInput.symbol,
             maxSnippets: parsedInput.maxSnippets,
-            maxNeighbors: parsedInput.maxNeighbors
+            maxNeighbors: parsedInput.maxNeighbors,
+            workspaceIdentity
           };
           const bundleResult = contextBundleOutputSchema.parse(await getContextBundle(bundleInput));
           const summaryPieces: string[] = [
@@ -1403,7 +1427,8 @@ async function main() {
           databaseName: parsedInput.databaseName,
           node: graphNode,
           direction: parsedInput.direction,
-          limit: parsedInput.limit
+          limit: parsedInput.limit,
+          workspaceIdentity
         };
         const graphResult = graphNeighborOutputSchema.parse(await graphNeighbors(graphInput));
         const neighborCount = graphResult.neighbors.length;
@@ -1449,7 +1474,8 @@ async function main() {
         const parsedInput = semanticSearchSchema.parse(normalizedInput);
         const context = createRootResolutionContext(extra);
         const resolvedRoot = resolveRootPath(parsedInput.root, context);
-        const searchInput = { ...parsedInput, root: resolvedRoot };
+        const workspaceIdentity = resolveWorkspaceIdentity(resolvedRoot, context);
+        const searchInput = { ...parsedInput, root: resolvedRoot, workspaceIdentity };
         const result = semanticSearchOutputSchema.parse(await semanticSearch(searchInput));
         const modelDescriptor = result.embeddingModel ? `model ${result.embeddingModel}` : 'stored embeddings';
         const summary = result.results.length
@@ -1486,7 +1512,8 @@ async function main() {
         const parsedInput = graphNeighborSchema.parse(normalizedInput);
         const context = createRootResolutionContext(extra);
         const resolvedRoot = resolveRootPath(parsedInput.root, context);
-        const graphInput = { ...parsedInput, root: resolvedRoot };
+        const workspaceIdentity = resolveWorkspaceIdentity(resolvedRoot, context);
+        const graphInput = { ...parsedInput, root: resolvedRoot, workspaceIdentity };
         const result = graphNeighborOutputSchema.parse(await graphNeighbors(graphInput));
         const neighborCount = result.neighbors.length;
         const directionDescriptor = parsedInput.direction ?? 'outgoing';
@@ -1524,11 +1551,12 @@ async function main() {
         const parsedInput = contextBundleInputSchema.parse(normalizedInput);
         const context = createRootResolutionContext(extra);
         const resolvedRoot = resolveRootPath(parsedInput.root, context);
-        
+        const workspaceIdentity = resolveWorkspaceIdentity(resolvedRoot, context);
+
         // Apply budget tokens from environment if not specified
         const budgetTokens = parsedInput.budgetTokens ?? getBudgetTokens();
-        
-        const bundleInput = { ...parsedInput, root: resolvedRoot, budgetTokens };
+
+        const bundleInput = { ...parsedInput, root: resolvedRoot, budgetTokens, workspaceIdentity };
         const result = contextBundleOutputSchema.parse(await getContextBundle(bundleInput));
 
         const summaryPieces: string[] = [
@@ -1632,7 +1660,8 @@ async function main() {
         const parsedInput = indexStatusSchema.parse(normalizedInput);
         const context = createRootResolutionContext(extra);
         const resolvedRoot = resolveRootPath(parsedInput.root, context);
-        const statusInput = { ...parsedInput, root: resolvedRoot };
+        const workspaceIdentity = resolveWorkspaceIdentity(resolvedRoot, context);
+        const statusInput = { ...parsedInput, root: resolvedRoot, workspaceIdentity };
         const result = indexStatusOutputSchema.parse(await getIndexStatus(statusInput));
 
         let summary: string;

--- a/src/status.ts
+++ b/src/status.ts
@@ -4,7 +4,8 @@ import path from 'node:path';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 
-import { DEFAULT_DB_FILENAME } from './constants.js';
+import { resolveIndexDatabasePath } from './index-storage.js';
+import type { WorkspaceIdentity } from './workspace-identity.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -12,6 +13,7 @@ export interface IndexStatusOptions {
   root: string;
   databaseName?: string;
   historyLimit?: number;
+  workspaceIdentity?: WorkspaceIdentity;
 }
 
 export interface IndexStatusIngestion {
@@ -75,7 +77,11 @@ async function getCurrentGitCommitSha(root: string): Promise<string | null> {
 
 export async function getIndexStatus(options: IndexStatusOptions): Promise<IndexStatusResult> {
   const absoluteRoot = path.resolve(options.root);
-  const dbPath = path.join(absoluteRoot, options.databaseName ?? DEFAULT_DB_FILENAME);
+  const { databasePath: dbPath } = resolveIndexDatabasePath(
+    absoluteRoot,
+    options.databaseName,
+    options.workspaceIdentity
+  );
 
   let databaseExists = false;
   let databaseSizeBytes: number | null = null;

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 
 import { DEFAULT_DB_FILENAME, DEFAULT_EXCLUDE_GLOBS, DEFAULT_INCLUDE_GLOBS } from './constants.js';
 import { ingestCodebase, type IngestOptions, type IngestResult } from './ingest.js';
+import type { WorkspaceIdentity } from './workspace-identity.js';
 import { createLogger } from './logger.js';
 
 export interface WatcherOptions {
@@ -10,6 +11,7 @@ export interface WatcherOptions {
   includeGlobs?: string[];
   excludeGlobs?: string[];
   databaseName?: string;
+  workspaceIdentity?: WorkspaceIdentity;
   debounceMs?: number;
   runInitial?: boolean;
   quiet?: boolean;
@@ -35,7 +37,7 @@ function toPosixPath(input: string): string {
 export async function startIngestWatcher(options: WatcherOptions): Promise<WatcherHandle> {
   const absoluteRoot = path.resolve(options.root);
   const includeGlobs = options.includeGlobs?.length ? options.includeGlobs : DEFAULT_INCLUDE_GLOBS;
-  const databaseName = options.databaseName ?? DEFAULT_DB_FILENAME;
+  const databaseName = path.basename(options.databaseName ?? DEFAULT_DB_FILENAME);
   const excludeGlobs = Array.from(
     new Set([
       ...DEFAULT_EXCLUDE_GLOBS,
@@ -72,6 +74,7 @@ export async function startIngestWatcher(options: WatcherOptions): Promise<Watch
       include: includeGlobs,
       exclude: excludeGlobs,
       databaseName,
+      workspaceIdentity: options.workspaceIdentity,
       maxFileSizeBytes: options.maxFileSizeBytes,
       storeFileContent: options.storeFileContent,
       contentSanitizer: options.contentSanitizer,

--- a/src/workspace-identity.ts
+++ b/src/workspace-identity.ts
@@ -1,0 +1,289 @@
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import type { RootResolutionContext } from './root-resolver.js';
+import { createLogger } from './logger.js';
+
+interface UnknownRecord {
+  [key: string]: unknown;
+}
+
+interface ProcessEnv {
+  [key: string]: string | undefined;
+}
+
+export interface WorkspaceIdentityComponent {
+  readonly value: string;
+  readonly source: string;
+}
+
+export interface WorkspaceIdentity {
+  readonly components: WorkspaceIdentityComponent[];
+}
+
+const HEADER_IDENTITY_KEYS = [
+  'x-workspace-id',
+  'x-workspace-slug',
+  'x-workspace-name',
+  'x-repo-id',
+  'x-repo-slug',
+  'x-repo-name',
+  'x-repo-url',
+  'x-repository',
+  'x-repository-id',
+  'x-repository-name',
+  'x-repository-url',
+  'x-github-repository',
+  'x-project-id',
+  'x-project-key',
+  'x-project-path'
+];
+
+const ENV_IDENTITY_KEYS = [
+  'MCP_WORKSPACE_ID',
+  'MCP_WORKSPACE_SLUG',
+  'MCP_WORKSPACE_NAME',
+  'MCP_PROJECT_ID',
+  'MCP_PROJECT_SLUG',
+  'WORKSPACE_ID',
+  'WORKSPACE_SLUG',
+  'WORKSPACE_NAME',
+  'PROJECT_ID',
+  'PROJECT_SLUG',
+  'PROJECT_KEY',
+  'PROJECT_PATH',
+  'REPOSITORY',
+  'REPOSITORY_ID',
+  'REPOSITORY_NAME',
+  'REPOSITORY_SLUG',
+  'REPOSITORY_URL',
+  'GITHUB_REPOSITORY',
+  'GIT_REPOSITORY',
+  'BITBUCKET_REPO_SLUG',
+  'CI_PROJECT_ID',
+  'CI_PROJECT_PATH',
+  'CI_REPOSITORY_URL'
+];
+
+const META_IDENTITY_KEY_PATTERN = /(workspace|repo|repository|project)(?:[_-]?(id|slug|name|url|path))?$/i;
+const MAX_COMPONENT_LENGTH = 512;
+const gitRemoteCache = new Map<string, string | null>();
+
+const log = createLogger('workspace-identity');
+
+function sanitizeValue(value: string | undefined): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > MAX_COMPONENT_LENGTH) {
+    return undefined;
+  }
+  return trimmed;
+}
+
+function addComponent(
+  seen: Set<string>,
+  components: WorkspaceIdentityComponent[],
+  source: string,
+  value: string | undefined
+) {
+  const sanitized = sanitizeValue(value);
+  if (!sanitized) {
+    return;
+  }
+  const key = `${source}::${sanitized}`;
+  if (seen.has(key)) {
+    return;
+  }
+  seen.add(key);
+  components.push({ source, value: sanitized });
+}
+
+function expandScalarList(value: string): string[] {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (Array.isArray(parsed)) {
+      return parsed
+        .filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
+        .map((item) => item.trim());
+    }
+  } catch {
+    // Fall through to delimiter parsing.
+  }
+
+  return trimmed
+    .split(/[\n;,]/)
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0);
+}
+
+function collectFromHeaders(headers: Record<string, string> | undefined): string[] {
+  if (!headers) {
+    return [];
+  }
+  const results: string[] = [];
+  for (const key of HEADER_IDENTITY_KEYS) {
+    const value = headers[key];
+    if (typeof value === 'string' && value) {
+      results.push(...expandScalarList(value));
+    }
+  }
+  return results;
+}
+
+function collectFromEnv(env: ProcessEnv | undefined): string[] {
+  const source = env ?? process.env;
+  const results: string[] = [];
+  for (const key of ENV_IDENTITY_KEYS) {
+    const value = source[key];
+    if (typeof value === 'string' && value) {
+      results.push(...expandScalarList(value));
+    }
+  }
+  return results;
+}
+
+function collectFromMeta(meta: UnknownRecord | undefined): string[] {
+  if (!meta) {
+    return [];
+  }
+
+  const visited = new Set<unknown>();
+  const results = new Set<string>();
+
+  const pushCandidate = (value: unknown) => {
+    if (typeof value === 'string') {
+      const sanitized = sanitizeValue(value);
+      if (sanitized) {
+        results.add(sanitized);
+      }
+    }
+  };
+
+  const traverse = (value: unknown, depth: number) => {
+    if (depth <= 0 || value === null || typeof value !== 'object') {
+      return;
+    }
+    if (visited.has(value)) {
+      return;
+    }
+    visited.add(value);
+
+    for (const [key, entryValue] of Object.entries(value as UnknownRecord)) {
+      if (!META_IDENTITY_KEY_PATTERN.test(key)) {
+        if (typeof entryValue === 'object' && entryValue !== null && depth > 1) {
+          traverse(entryValue, depth - 1);
+        }
+        continue;
+      }
+
+      if (typeof entryValue === 'string') {
+        pushCandidate(entryValue);
+      } else if (Array.isArray(entryValue)) {
+        for (const item of entryValue) {
+          if (typeof item === 'string') {
+            pushCandidate(item);
+          } else if (item && typeof item === 'object') {
+            traverse(item, depth - 1);
+          }
+        }
+      } else if (entryValue && typeof entryValue === 'object') {
+        traverse(entryValue, depth - 1);
+      }
+    }
+  };
+
+  traverse(meta, 3);
+  return Array.from(results);
+}
+
+function detectGitRemote(root: string): string | null {
+  const cached = gitRemoteCache.get(root);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  try {
+    const stdout = execFileSync('git', ['config', '--get', 'remote.origin.url'], {
+      cwd: root,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore']
+    });
+    const remote = sanitizeValue(stdout);
+    gitRemoteCache.set(root, remote ?? null);
+    return remote ?? null;
+  } catch (error) {
+    gitRemoteCache.set(root, null);
+    if (error && typeof error === 'object' && 'code' in error) {
+      const code = (error as { code?: string }).code;
+      if (code !== 'ENOENT') {
+        log.debug({ root, code }, 'git remote lookup failed');
+      }
+    }
+    return null;
+  }
+}
+
+function detectGitWorktree(root: string): string | null {
+  try {
+    const gitPath = path.join(root, '.git');
+    const stats = fs.statSync(gitPath);
+    if (stats.isFile()) {
+      const contents = fs.readFileSync(gitPath, 'utf8');
+      const match = /gitdir:\s*(.+)/i.exec(contents);
+      if (match?.[1]) {
+        const gitDir = sanitizeValue(match[1]);
+        if (gitDir) {
+          return path.resolve(root, gitDir);
+        }
+      }
+    } else if (stats.isDirectory()) {
+      return gitPath;
+    }
+  } catch {
+    // ignore errors
+  }
+  return null;
+}
+
+export function resolveWorkspaceIdentity(
+  root: string,
+  context: RootResolutionContext = {}
+): WorkspaceIdentity {
+  const absoluteRoot = path.resolve(root);
+  const components: WorkspaceIdentityComponent[] = [];
+  const seen = new Set<string>();
+
+  addComponent(seen, components, 'root', absoluteRoot);
+
+  for (const value of collectFromHeaders(context.headers)) {
+    addComponent(seen, components, 'header', value);
+  }
+
+  for (const value of collectFromEnv(context.env)) {
+    addComponent(seen, components, 'env', value);
+  }
+
+  for (const value of collectFromMeta(context.meta)) {
+    addComponent(seen, components, 'meta', value);
+  }
+
+  const gitRemote = detectGitRemote(absoluteRoot);
+  if (gitRemote) {
+    addComponent(seen, components, 'git-remote', gitRemote);
+  }
+
+  const gitWorktree = detectGitWorktree(absoluteRoot);
+  if (gitWorktree) {
+    addComponent(seen, components, 'gitdir', gitWorktree);
+  }
+
+  return { components };
+}


### PR DESCRIPTION
## Summary
- derive a workspace identity from headers/env/git metadata to namespace indexes and write an index-manifest alongside each database
- propagate the identity through ingest/search/bundle/graph/status/watch flows, exposing storage metadata in ingest responses
- document the managed storage layout, supported identity hints, and new ingest storage block for operators

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d932c2d588333b6bb0a23a6cf2ce0)